### PR TITLE
use safe version of sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl https://raw.githubusercontent.com/stencila/sibyl/master/sibyl.sh > ~/.local
 chmod 755 ~/.local/bin/sibyl
 ```
 
-`sibyl.sh` requires [`curl`](https://curl.haxx.se/), [`docker`](https://docs.docker.com/engine/installation/), [`jq`](https://stedolan.github.io/jq/) and `netstat` to be installed.
+`sibyl.sh` requires [`curl`](https://curl.haxx.se/), [`docker`](https://docs.docker.com/engine/installation/), [`jq`](https://stedolan.github.io/jq/) and `netstat` to be installed. On older versions of Mac OS which don't have the `sed -r` you may have to install `gsed` using `brew install coreutils`.
 
 Use `sibyl.sh` with a task name and bundle "address" e.g. 
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docs-build": "minidocs docs/ --assets docs/assets --css docs/styles.css --logo docs/logo.svg --contents docs/contents.json ---pushstate --output build/docs/",
     "docs-publish": "surge --domain sibyl.surge.sh build/docs/",
     "lint": "standard",
-    "start": "node server/server.js"
+    "start": "nodemon server/server.js"
   },
   "bin": {
     "sibyl": "./sibyl.sh"
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "minidocs": "^4.2.3",
+    "nodemon": "^1.11.0",
     "standard": "*",
     "surge": "^0.19.0"
   }

--- a/sibyl.sh
+++ b/sibyl.sh
@@ -50,9 +50,17 @@ if test -t 1; then
   fi
 fi
 
+# Use coreutils version of "sed" if available.
+gsed --help 2&> /dev/null
+if [ $? == 0 ]; then
+  sed="gsed"
+else
+  sed="sed"
+fi
+
 # Indent lines
 function indent {
-  sed 's/^/    /'
+  "$sed" 's/^/    /'
 }
 
 # Print a STEP to terminal
@@ -178,7 +186,7 @@ function fetch {
   info "Changed to directory $cyan'$PWD'$normal"
 
   # Do the fetch!
-  read scheme_ path_ <<< "$(echo "$1" | sed -rn "s!^(file|github)://(.+)!\1 \2!p")"
+  read scheme_ path_ <<< "$(echo "$1" | "$sed" -rn "s!^(file|github)://(.+)!\1 \2!p")"
   info "Fetching scheme '$cyan$scheme_$normal' with path '$cyan$path_$normal'"
   case $scheme_ in
     file)   fetch_file "$path_" ;;
@@ -219,7 +227,7 @@ function fetch_file_archive {
   # Get the archive file path and folder to extract from the address path
   local archive
   local folder
-  read archive folder <<< "$(echo "$path" | sed -r "s!^(.*(\.tar\.gz))(/(.+))?!\1 \4!")"
+  read archive folder <<< "$(echo "$path" | "$sed" -r "s!^(.*(\.tar\.gz))(/(.+))?!\1 \4!")"
   info "Fetching from file archive '${cyan}$archive${normal}' folder '${cyan}$folder${normal}'"
 
   # Extract into a temporary dir, move contents (including dot files)
@@ -242,7 +250,7 @@ function fetch_file_archive {
 function fetch_github {
   path=$1 # Address path i.e. repo/user/folder
 
-  read user repo folder <<< "$(echo "$path" | sed -r "s!^([^/]+?)/([^/]+)(/(.+))?!\1 \2 \4!")"
+  read user repo folder <<< "$(echo "$path" | "$sed" -r "s!^([^/]+?)/([^/]+)(/(.+))?!\1 \2 \4!")"
   info "Fetching Github repo '${cyan}$user/$repo${normal}' folder '${cyan}$folder${normal}'"
 
   # Download the archive
@@ -334,7 +342,7 @@ EOL
     # they are heavier solutions
     info "Using Node.js ${cyan}$version${normal}"
 
-    major=$(echo "$version" | sed -rn 's/([0-9]+)\..+/\1/p')
+    major=$(echo "$version" | "$sed" -rn 's/([0-9]+)\..+/\1/p')
 
     cat >> .sibyl/Dockerfile << EOL
 RUN curl -s "https://deb.nodesource.com/node_$major.x/pool/main/n/nodejs/nodejs_$version-1nodesource1~xenial1_amd64.deb" > node.deb \\
@@ -346,7 +354,7 @@ EOL
 
   # Parse dependencies in package.json into lines of name@version which can be xarged into
   # a npm global install
-  jq -r '.dependencies' package.json | sed -rn 's/  "([^"]+)": "([^"]+)",?/\1@\2/p' > .sibyl/node-requires.txt
+  jq -r '.dependencies' package.json | "$sed" -rn 's/  "([^"]+)": "([^"]+)",?/\1@\2/p' > .sibyl/node-requires.txt
 
   cat >> .sibyl/Dockerfile << EOL
 RUN cat ".sibyl/node-requires.txt" | xargs npm install
@@ -360,8 +368,8 @@ function install_python {
   # Get the Python version from requirements file e.g.
   #   # python==2.7
   # Note that any patch number in the version will be ignored
-  version=$(sed -rn 's/# *(P|p)ython==([0-9](\.[0-9]+)?).*/\2/p' requirements.txt)
-  major=$(echo "$version" | sed -rn 's/([0-9]+).*/\1/p')
+  version=$("$sed" -rn 's/# *(P|p)ython==([0-9](\.[0-9]+)?).*/\2/p' requirements.txt)
+  major=$(echo "$version" | "$sed" -rn 's/([0-9]+).*/\1/p')
 
   # Install Python and pip
   if [ "$version" == "" ]; then
@@ -403,7 +411,7 @@ function install_r {
 
   # Get the R version from requirements file e.g.
   #   # R==3.1.1
-  version=$(sed -rn 's/# *(R|r)==([0-9]\.[0-9]+\.[0-9]+)/\2/p' r-requires.txt)
+  version=$("$sed" -rn 's/# *(R|r)==([0-9]\.[0-9]+\.[0-9]+)/\2/p' r-requires.txt)
 
   # Install R
   if [ "$version" != "" ]; then
@@ -426,7 +434,7 @@ EOL
   cat > .sibyl/r-requires.R << EOL
 options(repos=structure(c(CRAN='https://cran.rstudio.com')))
 install.packages('devtools')
-$(sed -rn "s/^([a-zA-Z0-9]+)==(.*)/devtools::install_version('\1', '\2')/p" r-requires.txt)
+$("$sed" -rn "s/^([a-zA-Z0-9]+)==(.*)/devtools::install_version('\1', '\2')/p" r-requires.txt)
 devtools::install_github('stencila/r')
 stencila:::install()
 EOL
@@ -591,7 +599,7 @@ spec:
 EOF
 
     # Get the container's IP (to be used for routeing)
-    ip=$(kubectl get pods -o yaml | sed -rn "s!\s*podIP:\s(.*)!\1!p")
+    ip=$(kubectl get pods -o yaml | "$sed" -rn "s!\s*podIP:\s(.*)!\1!p")
     port="80"
 
     # TODO IP should be a public IP and we maintain a routing table to


### PR DESCRIPTION
Was having some trouble running the `sibyl` script on my Mac, figured other people might run into this too so I figured I'd fix it :sparkles:

## Changes
- use nodemon for `npm start` to get reloads while developing the server
- uses `gsed` if available; old versions of OS X don't have the `sed -r` flag
  - tried using an alias first, but that doesn't translate to subshells unfortunately
  - this allows people to unbreak their sed by doing `brew install coreutils`