### PR TITLE
prevent write after end

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/stencila/sibyl#readme",
   "dependencies": {
+    "end-of-stream": "^1.4.0",
     "koa": "^2.2.0",
     "koa-router": "^7.2.0",
     "koa-send": "^4.1.0",


### PR DESCRIPTION
Prevents the `"write after end"` error in #14. Turns out the reason for this error is that `koa` doesn't forward errors correctly - if the client closes a connection it closes the `res` before it closes the passthrough stream set to `body`. This causes writes to the passthrough stream to throw an error, as the res stream is already closed.

Koa is not using the [pump](http://ghub.io/pump) module, but instead (incorrectly) using the [`.pipe()` method.](https://github.com/koajs/koa/blob/ee5af59f1f847922c9cf41ccedbdbe6a3c024c2e/lib/application.js#L230) This means that errors are not being handled, and streams behavior between environments occur. On the streams WG we've decided to introduce `require('stream').pump` for this reason.