### PR TITLE
Fixes routing to container sessions for non-`GET /` methods and paths

### DIFF
--- a/client/launch.html
+++ b/client/launch.html
@@ -55,7 +55,7 @@
 
         var div = document.createElement('div');
         div.className = 'goto';
-        div.innerHTML = '<a href="/~session/' + token + '" target="_blank">Click here to open container</a>'
+        div.innerHTML = '<a href="/~session/' + token + '/" target="_blank">Click here to open container</a>'
         document.getElementsByTagName('body')[0].appendChild(div);
       }, false);
 

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -7,8 +7,9 @@ server {
     # Requires Nginx>=1.11.6 for proxy_method variable
     location ~ /proxy-to-session/(GET|POST|PUT|DELETE)/(.*) {
         internal;
-        proxy_method $1;
-        proxy_pass $2;
+        proxy_method        $1;
+        proxy_pass          $2;
+        proxy_set_header    X-Nginx         yes;
     }
 
     # Serve server.js

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -2,11 +2,13 @@ server {
     listen 80;
     server_name  localhost;
 
-    # Proxy request to container session after a [X-Accel-Redirect](http://wiki.nginx.org/X-accel) 
-    # header from server.js
-    location ~ /internal-session/(.*) {
+    # Following a [X-Accel-Redirect](http://wiki.nginx.org/X-accel) 
+    # header from server.js proxy request to container session
+    # Requires Nginx>=1.11.6 for proxy_method variable
+    location ~ /proxy-to-session/(GET|POST|PUT|DELETE)/(.*) {
         internal;
-        proxy_pass $1;
+        proxy_method $1;
+        proxy_pass $2;
     }
 
     # Serve server.js

--- a/server/server.js
+++ b/server/server.js
@@ -123,10 +123,9 @@ function sibylToStream (sibyl, req, res, ctx) {
   }
 }
 
-
 // Proxy/redirect requests to a container session
 function proxyToSession (req, res, ctx) {
-  const match = req.url.match(/\/~session\/([^\/]+)((\/)(.*))?/)
+  const match = req.url.match(/\/~session\/([^/]+)((\/)(.*))?/)
   const token = match[1]
   const slash = match[3]
   const path = match[4]

--- a/sibyl.sh
+++ b/sibyl.sh
@@ -607,7 +607,7 @@ EOF
 
   fi
 
-  echo -e "${magenta}GOTO${normal} http://$ip:$port/"
+  echo -e "${magenta}GOTO${normal} http://$ip:$port"
 }
 
 


### PR DESCRIPTION
I had a problem with a corrupt `.git` dir. In fixing it I ended up with the changes in PR `behind-nginx` as well. 