### PR TITLE
Dat support

### DIFF
--- a/sibyl.sh
+++ b/sibyl.sh
@@ -156,14 +156,16 @@ function image_id {
 ###############################################################################
 #
 # Fetch a bundle from an address:
-# 
+#
 # - `file://parent/folder` : a folder on the local filesystem
-# 
-# - `file://path/archive(.zip|tar.gz)/folder` : a folder within a file 
-#    archive on the local filesystem 
-# 
-# - `github://user/repo/parent/folder` :  a folder in a Github repo
-# 
+#
+# - `file://path/archive(.zip|tar.gz)/folder` : a folder within a file
+#    archive on the local filesystem
+#
+# - `github://user/repo/parent/folder` : a folder in a Github repo
+#
+# - `dat://key` : a Dat repo
+#
 ###############################################################################
 
 function fetch {
@@ -186,11 +188,12 @@ function fetch {
   info "Changed to directory $cyan'$PWD'$normal"
 
   # Do the fetch!
-  read scheme_ path_ <<< "$(echo "$1" | "$sed" -rn "s!^(file|github)://(.+)!\1 \2!p")"
+  read scheme_ path_ <<< "$(echo "$1" | "$sed" -rn "s!^(file|github|dat)://(.+)!\1 \2!p")"
   info "Fetching scheme '$cyan$scheme_$normal' with path '$cyan$path_$normal'"
   case $scheme_ in
     file)   fetch_file "$path_" ;;
-    github) fetch_github "$path_" ;;      
+    github) fetch_github "$path_" ;;
+    dat)    fetch_dat "$path_" ;;
     *)      error "Unknown scheme: $scheme_" ;;
   esac
 
@@ -269,10 +272,19 @@ function fetch_github {
   rm "$archive"
 }
 
+
+function fetch_dat {
+  info "Fetching Dat repo '${cyan}$1{normal}''"
+  info "Running '${cyan}dat $1 . --exit{normal}''"
+
+  # Download the archive
+  dat $1 . --exit
+}
+
 ###############################################################################
 #
 # Compile a Dockerfile for the bundle
-# 
+#
 ###############################################################################
 
 function compile {

--- a/sibyl.sh
+++ b/sibyl.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# 
+#
 # Configuration options
-# 
+#
 # The defaults below are intended for development using a local
 # Docker engine. For development using Minikube, or for deployment,
 # you'll need to change them.
-# 
+#
 ###############################################################################
 
 # The name of the Docker image to use in Docker file `FROM` statements
@@ -23,9 +23,9 @@
 : "${SIBYL_REGISTRY:=}"
 
 ###############################################################################
-# 
+#
 # Output and mocking functions and variables
-# 
+#
 ###############################################################################
 
 # Exclude from coverage
@@ -101,7 +101,7 @@ function unmock {
 ###############################################################################
 #
 # Bundle inspection
-# 
+#
 ###############################################################################
 
 # Translate a bundle address into a unique bundle name that
@@ -109,7 +109,7 @@ function unmock {
 function bundle_name {
   if [ "$1" != "" ]; then
     local name_
-    # Translate upper case to lower case, and 
+    # Translate upper case to lower case, and
     # any non-alpha-numerics to a dash
     # This used to include `iconv -t ascii//TRANSLIT` to translate non-ASCII
     # chars but that is not available in [Alpine Linux](https://github.com/gliderlabs/docker-alpine/issues/216)
@@ -136,7 +136,7 @@ function bundle_sha {
 }
 
 # Get the Docker image repository name and tag for the current bundle
-# In Docker a "repository" is any group of builds of an image with the same 
+# In Docker a "repository" is any group of builds of an image with the same
 # name, and potentially multiple tags (not to be confused with a Docker "registry")
 # See https://docs.docker.com/registry/spec/api/#overview for rules for repository
 # names
@@ -395,7 +395,7 @@ RUN apt-get update \\
 EOL
 
   else
-  
+
     info "Installing Python ${cyan}$version${normal}"
 
     cat >> .sibyl/Dockerfile << EOL
@@ -459,7 +459,7 @@ EOL
 ###############################################################################
 #
 # Build a container image for a bundle
-# 
+#
 ###############################################################################
 
 function build {
@@ -485,7 +485,7 @@ function build {
   fi
   if [ "$image_exists" != "" ]; then
     info "Image already built: $cyan'$image_id'$normal"
-    return 
+    return
   fi
 
   compile
@@ -521,7 +521,7 @@ function build {
 ###############################################################################
 #
 # Check the container has the expected environment
-# 
+#
 ###############################################################################
 
 function check {
@@ -537,7 +537,7 @@ function check {
 ###############################################################################
 #
 # Launch a container
-# 
+#
 ###############################################################################
 
 function launch {
@@ -566,7 +566,7 @@ function launch {
   # to the running bundle container
   local ip
   local port
-  
+
   # Run a container using...
   if [ "$SIBYL_CLUSTER" == "" ]; then
     # ...the local Docker engine
@@ -585,7 +585,7 @@ function launch {
 
   else
     # ...the Kubernetes cluster
-    
+
     info "Launching pod name:$cyan$name$normal"
     cat << EOF | kubectl create -f -
 
@@ -626,7 +626,7 @@ EOF
 ###############################################################################
 #
 # Main entry point
-# 
+#
 ###############################################################################
 # Exclude from coverage
 # LCOV_EXCL_START
@@ -658,7 +658,7 @@ if [ "${BASH_SOURCE[0]}" == "$0" ]; then
       build) build "$2" ;;
       check) check "$2" ;;
       launch) launch "$2" ;;
-        
+
       *)
         error "Unknown task: $1"
         ;;

--- a/sibyl.sh
+++ b/sibyl.sh
@@ -278,7 +278,7 @@ function fetch_dat {
   info "Running '${cyan}dat $1 . --exit{normal}''"
 
   # Download the archive
-  dat $1 . --exit
+  dat "$1" . --exit
 }
 
 ###############################################################################


### PR DESCRIPTION
requires `dat` on the CLI

output looks like this:

```
INFO Changed to directory '/Users/max/src/sibyl/bundles/dat-2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e-668956be3f'
INFO Fetching scheme 'dat' with path '2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e'
INFO Fetching Dat repo '2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e{normal}''
INFO Running 'dat 2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e . --exit{normal}''
[1000DConnecting to dat network...
[1A[1000D[0Kdat v13.6.0
Created new dat in /Users/max/src/sibyl/bundles/dat-2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e-668956be3f/.dat
Cloning: 2 files (8 B)
2 connections | Download 146 B/s Upload 0 B/s
dat sync complete.
Version 2
Exiting the Dat program...
INFO Building image: 'stencila/bundles/dat-2045e55542fd800f5b9aec6fb6ffa0e257a4a444f48023cec3cf499f0d9c4c8e-668956be3f:1169538874db8141e53d0a7bb973c3da57e33274'
    Sending build context to Docker daemon 24.06 kB
    Step 1/2 : FROM stencila/iota
     ---> bdb549ee9bbf
    Step 2/2 : COPY . .
     ---> 4936217afd4f
    Removing intermediate container f3712aa53fb7
    Successfully built 4936217afd4f
INFO Launching container name:bundle-8854 port:1032
    1ec2c37c26836c40f8f1cb573a832263b1c0effa06322d3971845be892e4ae17
```