### PR TITLE
Don't require gsed on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl https://raw.githubusercontent.com/stencila/sibyl/master/sibyl.sh > ~/.local
 chmod 755 ~/.local/bin/sibyl
 ```
 
-`sibyl.sh` requires [`curl`](https://curl.haxx.se/), [`docker`](https://docs.docker.com/engine/installation/), [`jq`](https://stedolan.github.io/jq/) and `netstat` to be installed. On older versions of Mac OS which don't have the `sed -r` you may have to install `gsed` using `brew install coreutils`.
+`sibyl.sh` requires [`curl`](https://curl.haxx.se/), [`docker`](https://docs.docker.com/engine/installation/), [`jq`](https://stedolan.github.io/jq/) and `netstat` to be installed.
 
 Use `sibyl.sh` with a task name and bundle "address" e.g. 
 

--- a/sibyl.sh
+++ b/sibyl.sh
@@ -242,7 +242,7 @@ function fetch_file_archive {
 function fetch_github {
   path=$1 # Address path i.e. repo/user/folder
 
-  read user repo folder <<< "$(echo "$path" | sed -E "s!^([^/]+?)/([^/]+)(/(.+))?!\1 \2 \4!")"
+  read user repo folder <<< "$(echo "$path" | sed -E "s!^([^/]+)/([^/]+)(/(.+))?!\1 \2 \4!")"
   info "Fetching Github repo '${cyan}$user/$repo${normal}' folder '${cyan}$folder${normal}'"
 
   # Download the archive


### PR DESCRIPTION
Use `sed -E` instead. The `E` flag is available on Mac and Linux (although as an undocumented alias to `r`)