### PR TITLE
Repurpose check(), use step, add warn

### DIFF
--- a/tests/dockerfile/test.sh
+++ b/tests/dockerfile/test.sh
@@ -7,9 +7,5 @@ fi
 
 launch
 
-# Shouldn't be anything in sibyl folder
-assert_exists .sibyl
-assert_empty "$(ls -1 .sibyl)"
-
 # There should be container running using this image
 assert_unempty "$(docker ps --filter="ancestor=$(image_id)" --quiet)"


### PR DESCRIPTION
Changes:

- `check` function now checks the layout of the document bundle before building and warns the user if missing "main" file

- `step` is used to provide more information to the user about what's happening

@yoshuawuyts : I added this to provide more feedback to the user. I was hoping you could grab the `STEP`s and indicate which step was currently going on. Also if there is a `WARN` you could show that in a message box.

When we refactor this to a real language ;) we should probably output all this as `ndjson`